### PR TITLE
Add thread count metric

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"runtime"
+	"runtime/pprof"
 	"time"
 )
 
@@ -38,6 +39,7 @@ var (
 		}
 		NumCgoCall   Gauge
 		NumGoroutine Gauge
+		NumThread    Gauge
 		ReadMemStats Timer
 	}
 	frees       uint64
@@ -45,6 +47,8 @@ var (
 	mallocs     uint64
 	numGC       uint32
 	numCgoCalls int64
+
+	threadCreateProfile = pprof.Lookup("threadcreate")
 )
 
 // Capture new values for the Go runtime statistics exported in
@@ -132,6 +136,8 @@ func CaptureRuntimeMemStatsOnce(r Registry) {
 	numCgoCalls = currentNumCgoCalls
 
 	runtimeMetrics.NumGoroutine.Update(int64(runtime.NumGoroutine()))
+
+	runtimeMetrics.NumThread.Update(int64(threadCreateProfile.Count()))
 }
 
 // Register runtimeMetrics for the Go runtime statistics exported in runtime and
@@ -166,6 +172,7 @@ func RegisterRuntimeMemStats(r Registry) {
 	runtimeMetrics.MemStats.TotalAlloc = NewGauge()
 	runtimeMetrics.NumCgoCall = NewGauge()
 	runtimeMetrics.NumGoroutine = NewGauge()
+	runtimeMetrics.NumThread = NewGauge()
 	runtimeMetrics.ReadMemStats = NewTimer()
 
 	r.Register("runtime.MemStats.Alloc", runtimeMetrics.MemStats.Alloc)
@@ -196,5 +203,6 @@ func RegisterRuntimeMemStats(r Registry) {
 	r.Register("runtime.MemStats.TotalAlloc", runtimeMetrics.MemStats.TotalAlloc)
 	r.Register("runtime.NumCgoCall", runtimeMetrics.NumCgoCall)
 	r.Register("runtime.NumGoroutine", runtimeMetrics.NumGoroutine)
+	r.Register("runtime.NumThread", runtimeMetrics.NumThread)
 	r.Register("runtime.ReadMemStats", runtimeMetrics.ReadMemStats)
 }


### PR DESCRIPTION
Benchmark results don't indicate a large performance decrease:

this branch:

```
$ for i in {1..5}; do go test -bench=Runtime; done
BenchmarkRuntimeMemStats      500000          5207 ns/op
BenchmarkRuntimeMemStats      300000          4126 ns/op
BenchmarkRuntimeMemStats      500000          2972 ns/op
BenchmarkRuntimeMemStats      500000          2887 ns/op
BenchmarkRuntimeMemStats      500000          4625 ns/op
```

rcrowley/go-metrics#7aeccdae5c4ea7140b90c8af1dcf9563065cc6dd (master):

```
$ for i in {1..5}; do go test -bench=Runtime; done
BenchmarkRuntimeMemStats      500000          3021 ns/op
BenchmarkRuntimeMemStats      300000          4616 ns/op
BenchmarkRuntimeMemStats      300000          4358 ns/op
BenchmarkRuntimeMemStats      500000          4376 ns/op
BenchmarkRuntimeMemStats      500000          4313 ns/op
```
